### PR TITLE
added examples for the new docker image parameters (UI and Core)

### DIFF
--- a/manager.yaml
+++ b/manager.yaml
@@ -2,6 +2,10 @@ parameters:
   hosts:
     api: trading.demo
     ui: ui.trading.demo
+  # --- change images for instances (e.g to use official freqtrade image)
+  # docker:
+  #   core_image: ph3nol/freqtrade:latest
+  #   ui_image: ph3nol/freqtrade-ui:latest
   # cors_domains:
   #   - ui.trading.com
   #   - ui.trading.net


### PR DESCRIPTION
Acompanying change for https://github.com/Ph3nol/Trading-Bot/pull/11. This adds the new parameters to the default config, demonstrating how one would set custom images to be used for Core/UI.